### PR TITLE
Removed single quotes ( ' ) from around the sample config tokens, as …

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@
 Code to download all the pictures from a given twitter account. It allows to filter retweets and replies if needed. Usage:
 
 positional arguments:
-  username    The twitter screen name from the account we want to retrieve all
-              the pictures
+  username         The twitter screen name from the account we want to
+                   retrieve all the pictures
 
 optional arguments:
-  -h, --help  show this help message and exit
-  --retweets  Include retweets
-  --replies   Include replies
+  -h, --help       show this help message and exit
+  --num NUM        Maximum number of tweets to be returned.
+  --retweets       Include retweets
+  --replies        Include replies
+  --output OUTPUT  folder where the pictures will be stored

--- a/sample-config.cfg
+++ b/sample-config.cfg
@@ -1,5 +1,5 @@
 [DEFAULT]
-consumer_key = 'YOUR-CONSUMER-KEY'
-consumer_secret = 'YOUR-CONSUMER-SECRET'
-access_token = 'YOUR-ACCESS-TOKEN'
-access_secret = 'YOUR-ACCESS-SECRET'
+consumer_key = YOUR-CONSUMER-KEY
+consumer_secret = YOUR-CONSUMER-SECRET
+access_token = YOUR-ACCESS-TOKEN
+access_secret = YOUR-ACCESS-SECRET


### PR DESCRIPTION
…configparser doesn't strip them, and it creates an authentication error if you call oauth with quoted tokens.  This "bug" led me to wasting a good amount of time trying to get the script to work before realizing that I needed to remove the quotes.

It may be better to .strip() these from the string instead, to be more user-proof, but I wanted to avoid making significant changes.

Additionally, updated README to include the optional arguments that weren't mentioned.