### PR TITLE
Add support for original file size download

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -67,10 +67,9 @@ def download_images(status, num_tweets, output_folder):
 
     for media_url in tweet_media_urls(tweet_status):
       # Only download if there is not a picture with the same name in the folder already
-
       file_name = os.path.split(media_url)[1]
       if not os.path.exists(os.path.join(output_folder, file_name)):
-	wget.download(media_url +":orig", out=output_folder+file_name)
+        wget.download(media_url +":orig", out=output_folder+'/'+file_name)
         downloaded += 1
 
 def download_images_by_user(api, username, retweets, replies, num_tweets, output_folder):

--- a/src/run.py
+++ b/src/run.py
@@ -67,10 +67,10 @@ def download_images(status, num_tweets, output_folder):
 
     for media_url in tweet_media_urls(tweet_status):
       # Only download if there is not a picture with the same name in the folder already
-      
+
       file_name = os.path.split(media_url)[1]
       if not os.path.exists(os.path.join(output_folder, file_name)):
-	wget.download(media_url +":orig", out=output_folder+media_url)
+	wget.download(media_url +":orig", out=output_folder+file_name)
         downloaded += 1
 
 def download_images_by_user(api, username, retweets, replies, num_tweets, output_folder):

--- a/src/run.py
+++ b/src/run.py
@@ -70,7 +70,7 @@ def download_images(status, num_tweets, output_folder):
       
       file_name = os.path.split(media_url)[1]
       if not os.path.exists(os.path.join(output_folder, file_name)):
-        wget.download(media_url, out=output_folder)
+	wget.download(media_url +":orig", out=output_folder+media_url)
         downloaded += 1
 
 def download_images_by_user(api, username, retweets, replies, num_tweets, output_folder):


### PR DESCRIPTION
Twitter creates 3 image formats when a user uploads a picture:
* The classic *.jpg filename
* A larger *.jpg:large filename
* The original size with a *.jpg:orig filename

Each "tag" changes the max size of the picture returned. If a picture is small (let's say 100x100px), :large and :orig won't throw an error but return the maximum size they are "allowed" to return.

This pull requests adds the support to download original-sized images, with the original filename instead of the :"orig"-suffixed one.